### PR TITLE
Added support for plug-in includes

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -59,4 +59,10 @@
   <link rel="microsub" href="https://micro.blog/microsub" />
   <link rel="webmention" href="https://micro.blog/webmention" />
   <link rel="subscribe" href="https://micro.blog/users/follow" />
+  {{ range .Site.Params.plugins_css }}
+    <link rel="stylesheet" href="{{ . }}" />
+  {{ end }}
+  {{ range $filename := .Site.Params.plugins_html }}
+    {{ partial $filename $ }}
+  {{ end }}
 </head>


### PR DESCRIPTION
This adds the HTML snippet to `<head>` that Micro.blog needs to insert CSS and JS from other Micro.blog plug-ins. Thanks!